### PR TITLE
SimpleCov plus Skunk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,7 @@ group :test do
   gem "minitest-bisect"
   gem "minitest-retry"
   gem "minitest-reporters"
+  gem "simplecov"
 
   platforms :mri do
     gem "stackprof"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,7 @@ GEM
       activerecord (>= 3.0, < 6.1)
       delayed_job (>= 3.0, < 5)
     digest-crc (0.4.1)
+    docile (1.3.2)
     em-http-request (1.1.5)
       addressable (>= 2.3.4)
       cookiejar (!= 0.3.1)
@@ -461,6 +462,10 @@ GEM
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
+    simplecov (0.18.1)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11.0)
+    simplecov-html (0.11.0)
     sinatra (2.0.7)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -593,6 +598,7 @@ DEPENDENCIES
   selenium-webdriver (>= 3.141.592)
   sequel
   sidekiq
+  simplecov
   sneakers
   sprockets-export
   sqlite3 (~> 1.4)
@@ -609,4 +615,4 @@ DEPENDENCIES
   websocket-client-simple!
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/Rakefile
+++ b/Rakefile
@@ -25,8 +25,12 @@ task default: %w(test test:isolated)
   desc "Run #{task_name} task for all projects"
   task task_name do
     errors = []
+    system("bundle install skunk")
     FRAMEWORKS.each do |project|
       system(%(cd #{project} && #{$0} #{task_name} --trace)) || errors << project
+      if task_name == "test"
+        system("skunk lib/")
+      end
     end
     fail("Errors in #{errors.join(', ')}") unless errors.empty?
   end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -10,6 +10,10 @@ require "active_support/core_ext/object/try"
 require "active_support/testing/autorun"
 require "active_storage/service/mirror_service"
 require "image_processing/mini_magick"
+require "simplecov"
+SimpleCov.start do
+  track_files "/lib/**/*.rb"
+end
 
 begin
   require "byebug"

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -4,6 +4,10 @@ ORIG_ARGV = ARGV.dup
 
 require "bundler/setup"
 require "active_support/core_ext/kernel/reporting"
+require "simplecov"
+SimpleCov.start do
+  track_files "/lib/**/*.rb"
+end
 
 silence_warnings do
   Encoding.default_internal = Encoding::UTF_8


### PR DESCRIPTION
### Summary

It adds code for SimpleCov and Skunk in order to: 

1. Calculate coverage for all frameworks
2. Calculate stink score for all frameworks

### Other Information

This is just a research PR, not planning to submit it to `rails/rails`
